### PR TITLE
Update InvokeMSI.Tests.ps1

### DIFF
--- a/TestHarnesses/T1218.007_Msiexec/InvokeMSI.Tests.ps1
+++ b/TestHarnesses/T1218.007_Msiexec/InvokeMSI.Tests.ps1
@@ -105,7 +105,7 @@ Describe 'Invoke-ATHMSI' {
             $Result.RunnerProcessId                   | Should -Not -BeNullOrEmpty
             $Result.RunnerProcessName                 | Should -Not -BeNullOrEmpty
             $Result.RunnerChildProcessId              | Should -Not -BeNullOrEmpty
-            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{4}\.tmp'
+            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{2,4}\.tmp'
             $Result.RunnerChildProcessCommandLine     | Should -Not -BeNullOrEmpty
         }
 
@@ -183,7 +183,7 @@ Describe 'Invoke-ATHMSI' {
             $Result.MsiExecProcessCommandLine         | Should -BeNull
             $Result.RunnerProcessId                   | Should -Not -BeNullOrEmpty
             $Result.RunnerChildProcessId              | Should -Not -BeNullOrEmpty
-            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{4}\.tmp'
+            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{2,4}\.tmp'
             $Result.RunnerChildProcessCommandLine     | Should -Not -BeNullOrEmpty
         }
 
@@ -261,7 +261,7 @@ Describe 'Invoke-ATHMSI' {
             $Result.MsiExecProcessCommandLine         | Should -BeNull
             $Result.RunnerProcessId                   | Should -Not -BeNullOrEmpty
             $Result.RunnerChildProcessId              | Should -Not -BeNullOrEmpty
-            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{4}\.tmp'
+            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{2,4}\.tmp'
             $Result.RunnerChildProcessCommandLine     | Should -Not -BeNullOrEmpty
         }
 
@@ -313,7 +313,7 @@ Describe 'Invoke-ATHMSI' {
             $Result.MsiExecProcessCommandLine         | Should -BeNull
             $Result.RunnerProcessId                   | Should -Not -BeNullOrEmpty
             $Result.RunnerChildProcessId              | Should -Not -BeNullOrEmpty
-            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{4}\.tmp'
+            $Result.RunnerChildProcessName            | Should -Match 'MSI[A-Z0-9]{2,4}\.tmp'
             $Result.RunnerChildProcessCommandLine     | Should -Not -BeNullOrEmpty
         }
     }


### PR DESCRIPTION
Fixed MSI Pester tests in cases where MSI tmp files have a variable-length hex suffix