### PR TITLE
New-ATHPortableExecutableRunner follows hard links

### DIFF
--- a/AtomicTestHarnesses.psd1
+++ b/AtomicTestHarnesses.psd1
@@ -4,7 +4,7 @@
 RootModule = 'Windows\AtomicTestHarnesses.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.13.0.0'
+ModuleVersion = '1.13.1.0'
 
 # ID used to uniquely identify this module
 GUID = '195a1637-d4a4-4cb3-8d80-5b5d4e3e930a'
@@ -67,6 +67,11 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
+1.13.1
+------
+Improvements:
+* New-ATHPortableExecutableRunner was tweaked to follow hard links in order to avoid defaulting to localized MUI directories which can lead to version info cloning inconsistencies.
+
 1.13.0
 ------
 Added:

--- a/Windows/TestHarnesses/T1204.002_MaliciousFile/PortableExecutableBuilder.ps1
+++ b/Windows/TestHarnesses/T1204.002_MaliciousFile/PortableExecutableBuilder.ps1
@@ -451,14 +451,22 @@ Outputs an object consisting of relevant executable details. The following objec
 
     if ($BuildResFile) {
         if ($TemplateFilePath) {
-            [Diagnostics.FileVersionInfo] $VersionInfo = Get-Item -Path $TemplateFilePath -ErrorAction Stop | Select-Object -ExpandProperty VersionInfo
+            $FileInfo = Get-Item -Path $TemplateFilePath -ErrorAction Stop
+
+            # There is a chance for version info inconsistency if the executable has a localized resource MUI directory in the same path as the executable.
+            # If the file has a hardlink, follow that as the target path is unlikely to have a localized MUI directory there.
+            if ($FileInfo.Target) {
+                [Diagnostics.FileVersionInfo] $VersionInfo = Get-Item -Path $FileInfo.Target[0] -ErrorAction Stop | Select-Object -ExpandProperty VersionInfo
+            } else {
+                [Diagnostics.FileVersionInfo] $VersionInfo = Get-Item -Path $TemplateFilePath -ErrorAction Stop | Select-Object -ExpandProperty VersionInfo
+            }
 
             $ResFileArguments = @{
                 FilePath = $ResFilePath
                 FileType = $PEType
             }
 
-            if ($VersionInfo.OriginalFilename)  { $ResFileArguments['OriginalFilename'] = $VersionInfo.OriginalFilename }
+            if ($VersionInfo.OriginalFilename) { $ResFileArguments['OriginalFilename'] = $VersionInfo.OriginalFilename }
             if ($VersionInfo.FileDescription)   { $ResFileArguments['FileDescription'] = $VersionInfo.FileDescription }
             if ($VersionInfo.ProductVersion)    { $ResFileArguments['ProductVersion'] = $VersionInfo.ProductVersion }
             if ($VersionInfo.InternalName)      { $ResFileArguments['InternalName'] = $VersionInfo.InternalName }


### PR DESCRIPTION
This change reduces the likelihood that when cloning PE version attributes that a MUI file is used as the template which can cause inconsistencies in version info reporting - i.e. version info derived from the binary itself (the most common expected scenario) versus version info derived from a localized MUI file. There are often inconsistencies between the original filename and file and product versions with a MUI when compared against the built-in version info resource.